### PR TITLE
Dependencies: Pip install 'us' package

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,8 +15,8 @@ dependencies:
 - matplotlib
 - pip
 - iminuit
-- us
 - fastparquet
 - pip:
   - boto3
   - click
+  - us


### PR DESCRIPTION
I get the following otherwise:
```
$ conda env create -f environment.yaml
Solving environment: failed

UnsatisfiableError: The following specifications were found to be in conflict:
  - python=3.7.3
  - us -> jellyfish==0.5.1 -> python=2.7 -> openssl=1.0
  - us -> jellyfish==0.5.1 -> python=2.7 -> python_abi=[build=*_cp27mu] -> pypy[version='<0a0']
Use "conda info <package>" to see the dependencies for each package.
```